### PR TITLE
FIX response body by renaming updatedAt to lwt

### DIFF
--- a/src/plugins/server/endpoint-replication.ts
+++ b/src/plugins/server/endpoint-replication.ts
@@ -105,7 +105,7 @@ export class RxServerReplicationEndpoint<ServerAppType, AuthType, RxDocType> imp
 
             const newCheckpoint = result.documents.length === 0 ? { id, lwt } : {
                 id: ensureNotFalsy(lastOfArray(result.documents))[primaryPath],
-                updatedAt: ensureNotFalsy(lastOfArray(result.documents))._meta.lwt
+                lwt: ensureNotFalsy(lastOfArray(result.documents))._meta.lwt
             };
             const responseDocuments = result.documents.map(d => removeServerOnlyFields(d));
             adapter.setResponseHeader(res, 'Content-Type', 'application/json');


### PR DESCRIPTION
The client looks for the `lwt` property but instead the server replies in some cases (documents > 0) with the property `updatedAt`. This way the client always requests the `lwt` `0` from the server and syncing never finishes when the whole collection doesn't fit inside just one `batchSize`.

I personally encountered this error for my use case and tinkered together this patch until the proper fix arrives:
```typescript
const expressRxServer = express();
    
expressRxServer.use( ( request, response, next ) => {
    
    const originalSend = response.send;
    
    response.send = function( body ) {
        
        const obj = JSON.parse( body );
        
        if ( obj.checkpoint?.updatedAt ) {
            obj.checkpoint.lwt = obj.checkpoint.updatedAt;
            delete obj.checkpoint.updatedAt;
        }
        
        return originalSend.call( this, JSON.stringify( obj ) );
    };
    
    next();
} );
```
    
After this synchronization started working.