### PR TITLE
ExpressAdapter: Use expressCors to apply CORS options to methods beyond OPTIONS

### DIFF
--- a/src/plugins/adapter-express/index.ts
+++ b/src/plugins/adapter-express/index.ts
@@ -16,7 +16,7 @@ export const RxServerAdapterExpress: RxServerAdapter<Express, Request, Response>
         return app;
     },
     setCors(serverApp, path, cors) {
-        serverApp.options('/' + path + '/*', expressCors({
+        serverApp.use('/' + path + '/*', expressCors({
             origin: cors,
             // some legacy browsers (IE11, various SmartTVs) choke on 204
             optionsSuccessStatus: 200


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

<!-- IMPORTANT:
  - EACH CHANGE TO THE SOURCE CODE, REQUIRES AT LEAST ONE TEST
    THAT COVERS THE CHANGE IN BEHAVIOR.
-->

<!--
  TO LEARN HOW TO MAKE THE PERFECT PULL REQUEST, READ THIS:
  https://simonwillison.net/2022/Oct/29/the-perfect-commit/
-->

## This PR contains:
 - SOMETHING ELSE


## Describe the problem you have without this PR
* CORS options for ExpressAdapter on rxdb-server should apply to more than just `OPTIONS`
* Addresses https://github.com/pubkey/rxdb/issues/6523

## Add pubkey

Then maintainer disabled notifications for this repo to not get all the messages from the renovate bots.
To ensure your human contribution is seen, add @pubkey here.
