### PR TITLE
Fix/express bigger body config

### DIFF
--- a/src/plugins/adapter-express/index.ts
+++ b/src/plugins/adapter-express/index.ts
@@ -10,9 +10,9 @@ import { ensureNotFalsy, getFromMapOrThrow } from 'rxdb/plugins/core';
 export const HTTP_SERVER_BY_EXPRESS = new WeakMap<Express, HttpServer>();
 
 export const RxServerAdapterExpress: RxServerAdapter<Express, Request, Response> = {
-    async create() {
+    async create(appOptions?:any) {
         const app = express();
-        app.use(express.json());
+        app.use(express.json(appOptions?.jsonOptions));
         return app;
     },
     setCors(serverApp, path, cors) {

--- a/src/plugins/server/index.ts
+++ b/src/plugins/server/index.ts
@@ -12,7 +12,7 @@ export async function createRxServer<ServerAdapterType, AuthType>(
 ): Promise<RxServer<ServerAdapterType, AuthType>> {
     options = flatClone(options);
     if (!options.serverApp) {
-        options.serverApp = await options.adapter.create();
+        options.serverApp = await options.adapter.create(options.appOptions);
     }
     const authHandler: RxServerAuthHandler<AuthType> = options.authHandler ? options.authHandler : () => {
         return {

--- a/src/plugins/server/types.ts
+++ b/src/plugins/server/types.ts
@@ -30,7 +30,7 @@ export type RxServerOptions<ServerAppType, AuthType> = {
 export type RxServerRouteHandler<RequestType = any, ResponseType = any> = (req: RequestType, res: ResponseType, next?: any) => MaybePromise<void>;
 
 export type RxServerAdapter<ServerAppType, RequestType = any, ResponseType = any> = {
-    create(): Promise<ServerAppType>;
+    create(appOptions?: any): Promise<ServerAppType>;
 
     get(app: ServerAppType, path: string, handler: RxServerRouteHandler<RequestType, ResponseType>): void;
     post(app: ServerAppType, path: string, handler: RxServerRouteHandler<RequestType, ResponseType>): void;


### PR DESCRIPTION
## This PR contains:
 Test and fix for [#7112](https://github.com/pubkey/rxdb/issues/7112).
 
## Describe the problem you have without this PR

By default express json parser defines a limit of 100kb for body size. Having a bigger body results in `413 Request entity too large`.
Once `app.use(express.json());` is called in the `RxServerAdapterExpress` function, further calls with different options are ignored, thus this PR implements a minor change, and uses the `appOptions` variable to allow for custom options to be handed to the `express.json()` call.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Typings
- [ ] Changelog


@pubkey
