### PR TITLE
Fix replication pull URL encoding for special characters in checkpoint ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fix replication pull URL not URL-encoding the checkpoint `id`. When a document's primary key contained URL-reserved characters (for example `&`, `#`, `=`), the URL was parsed incorrectly on the server, causing the checkpoint to be truncated. With `batchSize: 1` this could make the pull loop never advance past such a document. The client now encodes the `id` with `encodeURIComponent`.
 - Fix REST endpoint `/set` not protecting `serverOnlyFields` from client overwrites. Clients could include server-only fields in write requests to `/set`, and those values would be stored directly instead of being ignored. The handler now uses `mergeServerDocumentFields` (consistent with the replication endpoint) to ensure server-only field values are always preserved from the server-side document, not taken from client input.
 - Fix missing `await` in `RxRestClient.get()`, `RxRestClient.set()`, and `RxRestClient.delete()` methods. The `postRequest()` call was not awaited before calling `handleError()`, which caused server errors (e.g. 403 Forbidden from `changeValidator`) to be silently swallowed instead of thrown to the caller.
 - Fix conflict handling for new documents pushed via replication when `serverOnlyFields` are configured. `mergeServerDocumentFieldsMonad` incorrectly transformed a falsy `assumedMasterState` (used for new document inserts) into an object and set server-only fields to `null` on `newDocumentState`, causing schema validation failures and false conflicts.

--- a/src/plugins/replication-server/index.ts
+++ b/src/plugins/replication-server/index.ts
@@ -93,7 +93,7 @@ export function replicateServer<RxDocType>(
             async handler(checkpointOrNull, batchSize) {
                 const lwt = checkpointOrNull && checkpointOrNull.lwt ? checkpointOrNull.lwt : 0;
                 const id = checkpointOrNull && checkpointOrNull.id ? checkpointOrNull.id : '';
-                const url = options.url + `/pull?lwt=${lwt}&id=${id}&limit=${batchSize}`;
+                const url = options.url + `/pull?lwt=${lwt}&id=${encodeURIComponent(id)}&limit=${batchSize}`;
                 const response = await fetch(url, {
                     method: 'GET',
                     credentials: 'include',

--- a/test/unit/endpoint-replication.test.ts
+++ b/test/unit/endpoint-replication.test.ts
@@ -585,6 +585,54 @@ describe('endpoint-replication.test.ts', () => {
             clientCol.database.close();
         });
     });
+    describe('special characters in primary keys', () => {
+        it('should replicate documents whose primary key contains url-unsafe characters', async function () {
+            this.timeout(8000);
+
+            const col = await humansCollection.create(0);
+            // passport ids that contain characters which are relevant for URL query parsing.
+            await col.insert(schemaObjects.humanData('first-doc'));
+            await col.insert(schemaObjects.humanData('second&doc'));
+
+            const port = await nextPort();
+            const server = await createRxServer({
+                adapter: TEST_SERVER_ADAPTER,
+                database: col.database,
+                authHandler,
+                port
+            });
+            const endpoint = await server.addReplicationEndpoint({
+                name: randomToken(10),
+                collection: col
+            });
+            await server.start();
+
+            const clientCol = await humansCollection.create(0);
+            const url = 'http://localhost:' + port + '/' + endpoint.urlPath;
+            const replicationState = await replicateServer<HumanDocumentType>({
+                collection: clientCol,
+                replicationIdentifier: randomToken(10),
+                url,
+                headers,
+                live: false,
+                push: {},
+                // use batchSize=1 so the checkpoint id containing '&'
+                // is actually sent back to the server on a subsequent pull.
+                pull: { batchSize: 1 },
+                eventSource: EventSource
+            });
+            ensureReplicationHasNoErrors(replicationState);
+            await replicationState.awaitInSync();
+
+            const clientDocs = await clientCol.find().exec();
+            const clientIds = clientDocs.map(d => d.passportId).sort();
+            assert.deepStrictEqual(clientIds, ['first-doc', 'second&doc']);
+
+            await replicationState.cancel();
+            await col.database.close();
+            await clientCol.database.close();
+        });
+    });
     describe('.serverOnlyFields', () => {
         it('should not return serverOnlyFields to /pull requests', async () => {
             const col = await humansCollection.create(3);


### PR DESCRIPTION
## This PR contains:
- A BUGFIX
- IMPROVED TESTS

## Describe the problem you have without this PR

When replicating documents whose primary key contains URL-reserved characters (such as `&`, `#`, `=`), the replication pull request URL was not properly encoding the checkpoint `id` parameter. This caused the server to parse the URL incorrectly, truncating the checkpoint ID at the first special character. With `batchSize: 1`, this prevented the pull loop from advancing past documents with such primary keys, causing replication to hang.

## Changes

### Source Code
- **src/plugins/replication-server/index.ts**: Added `encodeURIComponent()` call when constructing the pull request URL to properly encode the checkpoint `id` parameter that may contain URL-reserved characters.

### Tests
- **test/unit/endpoint-replication.test.ts**: Added comprehensive test case `should replicate documents whose primary key contains url-unsafe characters` that verifies replication works correctly with primary keys containing special characters like `&`. The test uses `batchSize: 1` to ensure the encoded checkpoint ID is actually sent back to the server on subsequent pulls.

### Documentation
- **CHANGELOG.md**: Added entry documenting the bug fix.

## Test Plan

The new test case `should replicate documents whose primary key contains url-unsafe characters` covers this fix by:
1. Creating documents with primary keys containing URL-reserved characters (`&`)
2. Setting up a replication endpoint and client
3. Using `batchSize: 1` to force the checkpoint ID to be sent back to the server
4. Verifying that all documents are successfully replicated to the client

Existing tests continue to pass, confirming no regression in normal replication scenarios.

https://claude.ai/code/session_01KrbsDQ3tY2qPsJaaoGbWVa