### PR TITLE
fix(server): do not leak non-matching documents in /push conflict responses

### DIFF
--- a/orga/changelog/fix-push-conflict-response-leaks-non-matching-documents.md
+++ b/orga/changelog/fix-push-conflict-response-leaks-non-matching-documents.md
@@ -1,0 +1,1 @@
+- FIX (rx-server) the replication `/push` endpoint leaked documents that the `queryModifier` does not allow the client to see. Pushing a write for a foreign document id returned the full stored document inside the conflict response. The current server state of a written document is now checked against the `queryModifier` and non-matching writes are answered with `403 Forbidden`.

--- a/src/plugins/server/endpoint-replication.ts
+++ b/src/plugins/server/endpoint-replication.ts
@@ -152,6 +152,23 @@ export class RxServerReplicationEndpoint<ServerAppType, AuthType, RxDocType> imp
             const currentStateDocs = new Map<string, RxDocumentData<RxDocType>>();
             currentStateDocsArray.forEach(d => currentStateDocs.set((d as any)[primaryPath], d));
 
+            /**
+             * The client must also be allowed to access the state that is
+             * currently stored on the server for the documents it writes to.
+             * Only checking the client-provided newDocumentState/assumedMasterState
+             * is not enough: a client can send a write for the primary of a foreign
+             * document with a newDocumentState that matches the queryModifier and
+             * without an assumedMasterState. The write itself is then refused by
+             * the replication protocol because it is a conflict, but the conflict
+             * response contains the full stored master document which would leak
+             * documents that the queryModifier does not allow the client to see.
+             */
+            const nonAllowedServerDoc = currentStateDocsArray.find(d => !docDataMatcherWrite(d as any));
+            if (nonAllowedServerDoc) {
+                adapter.closeConnection(res, 403, 'Forbidden');
+                return;
+            }
+
             const useRows: typeof rows = rows.map((row) => {
                 const id = (row.newDocumentState as any)[primaryPath];
                 const isChangeValid = this.changeValidator(ensureNotFalsy(authData), {
@@ -182,6 +199,18 @@ export class RxServerReplicationEndpoint<ServerAppType, AuthType, RxDocType> imp
             }
 
             const conflicts = await replicationHandler.masterWrite(useRows);
+
+            /**
+             * The conflict response contains the documents as they are stored on
+             * the server. Ensure none of them is a document that the client is not
+             * allowed to see, for example when the stored document was changed by
+             * someone else between the check above and the write.
+             */
+            const nonAllowedConflict = conflicts.find(c => !docDataMatcherWrite(c as any));
+            if (nonAllowedConflict) {
+                adapter.closeConnection(res, 403, 'Forbidden');
+                return;
+            }
 
             adapter.setResponseHeader(res, 'Content-Type', 'application/json');
             adapter.endResponseJson(res, conflicts.map(c => removeServerOnlyFields(c)));

--- a/test/unit/endpoint-replication.test.ts
+++ b/test/unit/endpoint-replication.test.ts
@@ -519,6 +519,67 @@ describe('endpoint-replication.test.ts', () => {
             serverCol.database.close();
             clientCol.database.close();
         });
+        it('should not leak non-matching documents in the /push conflict response', async () => {
+            const serverCol = await humansCollection.create(0);
+
+            /**
+             * A document that belongs to another user ('bob').
+             * The client below authenticates as 'alice' and the queryModifier
+             * only allows it to see documents where firstName === 'alice',
+             * so the content of this document must never reach the client.
+             */
+            const foreignDocId = 'foreign-doc';
+            const foreignDoc = schemaObjects.humanData(foreignDocId, 42, 'bob');
+            foreignDoc.lastName = 'TopSecretLastName';
+            await serverCol.insert(foreignDoc);
+
+            const port = await nextPort();
+            const server = await createRxServer({
+                adapter: TEST_SERVER_ADAPTER,
+                database: serverCol.database,
+                authHandler,
+                port
+            });
+            const endpoint = await server.addReplicationEndpoint({
+                name: randomToken(10),
+                collection: serverCol,
+                queryModifier
+            });
+            await server.start();
+
+            /**
+             * The client pushes a write for the primary key of the foreign
+             * document. It passes the write checks because the
+             * newDocumentState is crafted to match the queryModifier and no
+             * assumedMasterState is sent.
+             */
+            const url = 'http://localhost:' + port + '/' + endpoint.urlPath + '/push';
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    ...headers,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify([{
+                    newDocumentState: {
+                        passportId: foreignDocId,
+                        firstName: headers.userid,
+                        lastName: 'anything',
+                        age: 1,
+                        _deleted: false
+                    }
+                }])
+            });
+            const responseBody = await response.text();
+
+            assert.ok(
+                !responseBody.includes('TopSecretLastName') && !responseBody.includes('"bob"'),
+                'The server must not return the content of a document that the queryModifier does not allow the client to see, got: ' + responseBody
+            );
+            assert.strictEqual(response.status, 403);
+
+            await serverCol.database.close();
+        });
     });
     describe('changeValidator', () => {
         const changeValidator: RxServerChangeValidator<AuthType, HumanDocumentType> = (authData, change) => {


### PR DESCRIPTION
## This PR contains:

A BUGFIX (security).

## Describe the problem you have without this PR

The replication `/push` endpoint validates the client-provided `newDocumentState` and — only when it is present — `assumedMasterState` against the `queryModifier`. It never checks the document that is **actually stored on the server** under the written primary key.

A client can exploit this to read documents the `queryModifier` forbids:

1. Pick the primary key of a foreign document.
2. Send a push row with a `newDocumentState` crafted to match the client's own `queryModifier` scope, and **omit** `assumedMasterState`.
3. Both write checks pass. `masterWrite` then sees an existing master with no assumed state, refuses the write and returns the stored master document as a conflict.
4. That conflict array is sent straight back to the client. Only `serverOnlyFields` / `_meta` / `_rev` are stripped — the `queryModifier` is never applied to it.

Any authenticated client could therefore dump arbitrary documents — other users', other tenants' — one primary key at a time (or many per request), completely bypassing the plugin's central authorization mechanism.

Reproduced by the new test: a client authenticated as `alice`, restricted by a `queryModifier` to `firstName === 'alice'`, receives the full contents of a document owned by `bob`:

```
AssertionError: The server must not return the content of a document that the
queryModifier does not allow the client to see, got:
[{"passportId":"foreign-doc","firstName":"bob","lastName":"TopSecretLastName","age":42,"_deleted":false}]
```

### Fix

- The current server state of every written document is matched against the `queryModifier`; a non-matching write is answered with `403 Forbidden`.
- The conflict response is checked as well, so a concurrent modification between that check and the write cannot leak a document either.

The equivalent check already exists on the REST `/set` endpoint (`endpoint-rest.ts`, "The user must also be allowed to access the existing document") — `/push` was the remaining gap.

## Todos

- [x] Tests — `should not leak non-matching documents in the /push conflict response` in `test/unit/endpoint-replication.test.ts`, which fails before the change and passes after it. Full unit suite: 62 passing.
- [ ] Documentation — no documented behavior changes.
- [ ] Typings — unchanged.
- [x] Changelog — `orga/changelog/fix-push-conflict-response-leaks-non-matching-documents.md`

## Add pubkey

@pubkey

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2A8KKJjKCAE2eARZnnNpk)_